### PR TITLE
chore: demote per-request "compression enabled" log to Debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Deprecation** The `dgrpc.ListenAndServe` is deprecated sses `server := dgrpc.NewServer2(options...)` with the `dgrpc.WithHealthCheck(dgrpc.HealthCheckOverHTTP, ...)` then `go server.Launch()` instead.
 - move from deprecated `github.com/bufbuild/connect-go` to `connectrpc.com/connect`
 
+### Changed
+
+- Demote the per-request `compression enabled` log from Info to Debug — it fired on every request and carried no actionable signal.
+
 ## 2020-03-21
 
 ### Changed

--- a/server/standard/compression.go
+++ b/server/standard/compression.go
@@ -32,7 +32,7 @@ func CompressionHandler(enforceCompression bool, h http.Handler) http.Handler {
 					return
 				}
 
-				zlog.Info("compression enabled", zap.String("grpc-encoding", compressor))
+				zlog.Debug("compression enabled", zap.String("grpc-encoding", compressor))
 				h.ServeHTTP(w, r)
 				return
 			}
@@ -51,7 +51,7 @@ func CompressionHandler(enforceCompression bool, h http.Handler) http.Handler {
 			}
 		}
 
-		zlog.Info("compression enabled", zap.String("grpc-encoding", compressor))
+		zlog.Debug("compression enabled", zap.String("grpc-encoding", compressor))
 		r.Header.Add("grpc-encoding", compressor)
 		h.ServeHTTP(w, r)
 


### PR DESCRIPTION
## What

`CompressionHandler` in `server/standard/compression.go` logged `compression enabled` at **Info** on every single HTTP/gRPC request — both in the branch where the client explicitly selects an encoding via the `grpc-encoding` header, and in the fall-through branch that negotiates from `grpc-accept-encoding` / `connect-accept-encoding` / `accept-encoding`.

Both are now logged at **Debug**.

## Why

Services embedding the standard server (portal-api, sidecar, session) emit this for essentially every request whenever the `dgrpc` logger sits at Info, which is the default in local development:

```
[2026-07-31 13:35:47.687 EDT] INFO (dgrpc) compression enabled {"grpc-encoding":"gzip"}
[2026-07-31 13:35:47.748 EDT] INFO (dgrpc) compression enabled {"grpc-encoding":"identity"}
```

It carries no actionable signal and drowns out real log output.

## Scope

Level change only — same message text, same fields, same control flow. The `writeBadRequest` error paths and `firstSupportedCompressor` are untouched. CHANGELOG updated under `## Unreleased` / `### Changed`.

## Verification

`go build ./...` and `go test ./...` both pass.